### PR TITLE
Destination Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # oh-my-zsh-aws-mfa
+
 oh-my-zsh plugin for AWS CLI MFA
 based on [https://github.com/sweharris/aws-cli-mfa](https://github.com/sweharris/aws-cli-mfa)
 support for passing totp as an argument added by [kt-caylent](https://github.com/kt-caylent)
 
 ## Using settings from .aws/config
+
 Now also supports "mfa_device" that is specified in profile (even with "source_profile").
 
 When "role_arn" is specified, it will assume the role after successful mfa login, and set the credentials for that assumed role
 
-
 ## Install Oh-My-Zsh AWS MFA Plugin
-1) ```git clone --depth=1 https://github.com/joepjoosten/aws-cli-mfa-oh-my-zsh.git "$ZSH/custom/plugins/aws-mfa"```
-2) enable it in plugins=(... aws-mfa) in your zshrc file
-3) source ~/.zshrc
+
+1. `git clone --depth=1 https://github.com/joepjoosten/aws-cli-mfa-oh-my-zsh.git "$ZSH/custom/plugins/aws-mfa"`
+2. enable it in plugins=(... aws-mfa) in your zshrc file
+3. source ~/.zshrc
 
 ## Using Oh-My-Zsh AWS MFA Plugin
-This plugin adds a new zsh alias, `aws-mfa`, this plugin has four ways you can use it:
 
-1) Call `aws-mfa` with no arguments.  This will cause it to prompt you interactively for a TOTP code for your current active AWS_PROFILE.
-2) Call `aws-mfa 123456` where **123456** is your 6-digit mfa code from your virtual MFA device (such as Google Authenticator, FreeOTP, etc)
-3) Call `aws-mfa my-aws-profile` where **my-aws-profile** is the name of the AWS_PROFILE you want to mfa authenticate to.  It will prompt for TOTP as in case #1.
-4) Call `aws-mfa my-aws-profile 123456` where **my-aws-profile** is the name of the AWS_PROFILE you want to mfa authenticate to and **123456** is your TOTP code.
+This plugin adds a new zsh alias, `aws-mfa`, this plugin has five ways you can use it:
 
-Note: Options 3 and 4 only make sense if you don't have an AWS_PROFILE already defined.  The objective being to go from having no AWS_PROFILE defined to having mfa-authenticated STS temporary credentials in one command.  
+1. Call `aws-mfa` with no arguments. This will cause it to prompt you interactively for a TOTP code for your current active AWS_PROFILE.
+2. Call `aws-mfa 123456` where **123456** is your 6-digit mfa code from your virtual MFA device (such as Google Authenticator, FreeOTP, etc)
+3. Call `aws-mfa my-aws-profile` where **my-aws-profile** is the name of the AWS_PROFILE you want to mfa authenticate to. It will prompt for TOTP as in case #1.
+4. Call `aws-mfa my-aws-profile 123456` where **my-aws-profile** is the name of the AWS_PROFILE you want to mfa authenticate to and **123456** is your TOTP code.
+5. Call `aws-mfa my-aws-profile 123456 temp-profile` where **my-aws-profile** is the name of the AWS_PROFILE to mfa authenticate to, **123456** is your TOTP code, and **temp-profile** is the name of the AWS_PROFILE to write the temporary credentials to
 
-Furthermore, if you are using the zsh plugin for aws and have set your profile using it's `asp` function, this will interfere with both options 3 and 4, because it will inject it's AWS_PROFILE information into all subshells, causing all requests to utilize the profile defined with `asp` rather than the argument you provide here.  You can correct for this by running `asp` with no arguments to unset the profile, and these setting will once again work as outlined above.
+Note: Options 3, 4, and 5 only make sense if you don't have an AWS_PROFILE already defined. The objective being to go from having no AWS_PROFILE defined to having mfa-authenticated STS temporary credentials in one command.
+
+Furthermore, if you are using the zsh plugin for aws and have set your profile using it's `asp` function, this will interfere with both options 3 and 4, because it will inject it's AWS_PROFILE information into all subshells, causing all requests to utilize the profile defined with `asp` rather than the argument you provide here. You can correct for this by running `asp` with no arguments to unset the profile, and these setting will once again work as outlined above.

--- a/get-aws-creds
+++ b/get-aws-creds
@@ -94,10 +94,17 @@ $tokens" >&2
   exit 255
 fi
 
+if [ -z "$DESTINATION_PROFILE" ]
+then
+  destination_profile="current_session"
+else
+  destination_profile=$DESTINATION_PROFILE
+fi
+
 if [ -n "$config_region" ]
 then
   echo export AWS_DEFAULT_REGION=$config_region
-  aws configure set region $config_region --profile current_session
+  aws configure set region $config_region --profile $destination_profile
 fi
 
 if [ -z "$config_role_arn" ]
@@ -105,9 +112,9 @@ then
   echo export AWS_SESSION_TOKEN=$session
   echo export AWS_SECRET_ACCESS_KEY=$secret
   echo export AWS_ACCESS_KEY_ID=$access
-  aws configure set aws_access_key_id $access --profile current_session
-  aws configure set aws_secret_access_key $secret --profile current_session
-  aws configure set aws_session_token $session --profile current_session
+  aws configure set aws_access_key_id $access --profile $destination_profile
+  aws configure set aws_secret_access_key $secret --profile $destination_profile
+  aws configure set aws_session_token $session --profile $destination_profile
 else
   export AWS_SESSION_TOKEN=$session
   export AWS_SECRET_ACCESS_KEY=$secret
@@ -126,9 +133,9 @@ else
   echo export AWS_SECRET_ACCESS_KEY=$secret
   echo export AWS_ACCESS_KEY_ID=$access
 
-  aws configure set aws_access_key_id $access --profile current_session
-  aws configure set aws_secret_access_key $secret --profile current_session
-  aws configure set aws_session_token $session --profile current_session
+  aws configure set aws_access_key_id $access --profile $destination_profile
+  aws configure set aws_secret_access_key $secret --profile $destination_profile
+  aws configure set aws_session_token $session --profile $destination_profile
 fi
 
 echo Keys valid until $expire >&2

--- a/getaws
+++ b/getaws
@@ -4,6 +4,9 @@ getaws()
   if [[ $1 =~ [0-9]{6} ]]
   then 
     eval $(AWS_MFA_CODE=$1 ~/.oh-my-zsh/custom/plugins/aws-mfa/get-aws-creds)
+  elif [ -n $3 ]
+  then
+    eval $(AWS_PROFILE=$1 AWS_MFA_CODE=$2 DESTINATION_PROFILE=$3 ~/.oh-my-zsh/custom/plugins/aws-mfa/get-aws-creds)
   else
     eval $(AWS_PROFILE=$1 AWS_MFA_CODE=$2 ~/.oh-my-zsh/custom/plugins/aws-mfa/get-aws-creds)
   fi


### PR DESCRIPTION
Enable setting a destination AWS CLI profile where the generated temporary credentials will be written (in addition to setting the shell variables).

This will facilitate the usage of the generated credentials in subshells and scripts that prefer to explicitly reference an AWS profile.