### PR TITLE
Updated another hardcoded value of --duration-seconds to use config_duration_seconds

### DIFF
--- a/get-aws-creds
+++ b/get-aws-creds
@@ -85,7 +85,7 @@ else
   code=$AWS_MFA_CODE
 fi
 
-tokens=$(aws sts get-session-token --serial-number "$device" --token-code $code --duration-seconds 3600)
+tokens=$(aws sts get-session-token --serial-number "$device" --token-code $code --duration-seconds $config_duration_seconds)
 
 secret=$(echo -- "$tokens" | sed -n 's!.*"SecretAccessKey": "\(.*\)".*!\1!p')
 session=$(echo -- "$tokens" | sed -n 's!.*"SessionToken": "\(.*\)".*!\1!p')


### PR DESCRIPTION
While `$config_duration_seconds` is set at the start of the file, the value for `--duration-seconds` was still hardcoded on one line. I updated the other `get-session-token` call to use `$config_duration_seconds`.